### PR TITLE
Add URL component encoding in nodejs app for passed commands

### DIFF
--- a/source/opt/nodejs/public/javascripts/tool.js
+++ b/source/opt/nodejs/public/javascripts/tool.js
@@ -38,7 +38,7 @@ function scrollTerminalToBottom() {
 
 function runTask() {
   clear();
-  const argument = $('#task-argument').val().trim();
+  const argument = encodeURIComponent($('#task-argument').val().trim());
   if (argument.length > 0) {
     setupWebSocket(`task?argument=${argument}`);
     $('#task-argument').val('');


### PR DESCRIPTION
Without `encodeURIComponent`, some arguments (entered by the user into the web app text box) are unintentionally shortened at the first special character. This leads to bugs, e.g., arguments that contain base64 encoded values are shortened to the prefix up to the first `=` sign. The rest of the message is dropped. `encodeURIComponent` properly encodes the argument.